### PR TITLE
Fix marketplace.json skill paths (add missing skills/ prefix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,14 +15,14 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./appsec/sast-semgrep",
-        "./appsec/sast-bandit",
-        "./appsec/dast-zap",
-        "./appsec/dast-nuclei",
-        "./appsec/api-mitmproxy",
-        "./appsec/api-spectral",
-        "./appsec/dast-ffuf",
-        "./appsec/sca-blackduck"
+        "./skills/appsec/sast-semgrep",
+        "./skills/appsec/sast-bandit",
+        "./skills/appsec/dast-zap",
+        "./skills/appsec/dast-nuclei",
+        "./skills/appsec/api-mitmproxy",
+        "./skills/appsec/api-spectral",
+        "./skills/appsec/dast-ffuf",
+        "./skills/appsec/sca-blackduck"
       ]
     },
     {
@@ -31,12 +31,12 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./devsecops/secrets-gitleaks",
-        "./devsecops/iac-checkov",
-        "./devsecops/container-grype",
-        "./devsecops/container-hadolint",
-        "./devsecops/sca-trivy",
-        "./devsecops/vuln-defectdojo"
+        "./skills/devsecops/secrets-gitleaks",
+        "./skills/devsecops/iac-checkov",
+        "./skills/devsecops/container-grype",
+        "./skills/devsecops/container-hadolint",
+        "./skills/devsecops/sca-trivy",
+        "./skills/devsecops/vuln-defectdojo"
       ]
     },
     {
@@ -45,9 +45,9 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./secsdlc/reviewdog",
-        "./secsdlc/sast-horusec",
-        "./secsdlc/sbom-syft"
+        "./skills/secsdlc/reviewdog",
+        "./skills/secsdlc/sast-horusec",
+        "./skills/secsdlc/sbom-syft"
       ]
     },
     {
@@ -56,7 +56,7 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./compliance/policy-opa"
+        "./skills/compliance/policy-opa"
       ]
     },
     {
@@ -65,9 +65,9 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./incident-response/detection-sigma",
-        "./incident-response/forensics-osquery",
-        "./incident-response/ir-velociraptor"
+        "./skills/incident-response/detection-sigma",
+        "./skills/incident-response/forensics-osquery",
+        "./skills/incident-response/ir-velociraptor"
       ]
     },
     {
@@ -76,7 +76,7 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./threatmodel/pytm"
+        "./skills/threatmodel/pytm"
       ]
     },
     {
@@ -85,15 +85,15 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./offsec/pentest-metasploit",
-        "./offsec/recon-nmap",
-        "./offsec/network-netcat",
-        "./offsec/ot-security-assessment",
-        "./offsec/analysis-tshark",
-        "./offsec/webapp-sqlmap",
-        "./offsec/webapp-nikto",
-        "./offsec/crack-hashcat",
-        "./offsec/privesc-linpeas"
+        "./skills/offsec/pentest-metasploit",
+        "./skills/offsec/recon-nmap",
+        "./skills/offsec/network-netcat",
+        "./skills/offsec/ot-security-assessment",
+        "./skills/offsec/analysis-tshark",
+        "./skills/offsec/webapp-sqlmap",
+        "./skills/offsec/webapp-nikto",
+        "./skills/offsec/crack-hashcat",
+        "./skills/offsec/privesc-linpeas"
       ]
     }
   ]


### PR DESCRIPTION
## Problem

After `claude plugin marketplace add` + enabling any plugin from this kit, every plugin hard-fails to load its skills, e.g.:

```
Path not found: .../appsec-skills/<hash>/appsec/sast-semgrep (skills)
```

All 7 plugins are affected (appsec-skills, devsecops-skills, secsdlc-skills, compliance-skills, incident-response-skills, threatmodel-skills, offsec-skills).

## Root cause

In the root `.claude-plugin/marketplace.json`, every plugin uses `"source": "./"` and declares its skills as `"./<category>/<skill>"` — e.g. `"./appsec/sast-semgrep"`. But the skills actually live one level down, under `skills/<category>/<skill>` (e.g. `skills/appsec/sast-semgrep/SKILL.md`).

With `source: "./"`, those paths resolve to `<repo-root>/<category>/…`, which does not exist — so loading fails. (There is a second, correct `marketplace.json` under `skills/`, but the **root** manifest is the one Claude Code reads when the marketplace is added, so that's the one that breaks.)

## Fix

Prefix all 31 skill paths across all 7 plugins with `skills/`. `source` is left as `"./"`.

```diff
       "skills": [
-        "./appsec/sast-semgrep",
+        "./skills/appsec/sast-semgrep",
         ...
```

## Verification

Every corrected path was checked against the tree — all 31 resolve to an existing `SKILL.md`. No other changes.
